### PR TITLE
Maneter la cookie gameId cuando se inicia una partida privada

### DIFF
--- a/app/src/main/java/eina/unizar/frontend_movil/ui/screens/MainMenuScreen.kt
+++ b/app/src/main/java/eina/unizar/frontend_movil/ui/screens/MainMenuScreen.kt
@@ -131,8 +131,19 @@ fun PlayerProgress(navController: NavController) {
         val userPrefs = context.getSharedPreferences("user_prefs", Context.MODE_PRIVATE)
         val editor = userPrefs.edit()
         editor.putString("username", username)
-        editor.putString("PlayerID", userId)
+        if (userId == null) {
+            // Crear un nuevo uuid aleatorio
+            val randomUUID = java.util.UUID.randomUUID().toString()
+            editor.putString("PlayerID", randomUUID)
+        } else {
+            editor.putString("PlayerID", userId)
+        }
         editor.apply()
+        context.getSharedPreferences("game_prefs", Context.MODE_PRIVATE)
+            .edit()
+            .remove("gameId")
+            .apply()
+
     }
 
     DisposableEffect(Unit) {

--- a/app/src/main/java/eina/unizar/frontend_movil/ui/screens/PrivateRoomScreen.kt
+++ b/app/src/main/java/eina/unizar/frontend_movil/ui/screens/PrivateRoomScreen.kt
@@ -457,7 +457,7 @@ private suspend fun handleScreenExit(
             // Limpiamos también los datos de la partida
             context.getSharedPreferences("game_prefs", Context.MODE_PRIVATE)
                 .edit()
-                .remove("gameId")
+                //.remove("gameId")
                 .remove("gamePasswd")
                 .apply()
         }


### PR DESCRIPTION
Pequeño cambio para las partidas privadas, hay que mantener la cookie gameId para saber si es una partida privada o no.